### PR TITLE
Adjust relative link to initiatives for frontpage

### DIFF
--- a/_layouts/frontpage.html
+++ b/_layouts/frontpage.html
@@ -29,7 +29,7 @@
 
                     {% for initiative in site.initiatives %}
 
-                    <a href="/{{ initiative.permalink }}" class="usa-width-one-third initiative-block">
+                    <a href="..{{ initiative.permalink }}" class="usa-width-one-third initiative-block">
                         <h3>{{ initiative.title }}</h3>
                     </a>
 


### PR DESCRIPTION
Copying the adjustment made to the initiatives.html so that links to initiatives redirect appropriately from homepage