### PR TITLE
Make main/master the default branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,10 +11,17 @@ See [CONTRIBUTING](CONTRIBUTING.md) for additional information.
 
 This site is automatically published based on the branch.
 
-Branch    | Environment | URL
-------    | ----------- | ---
-`develop` | staging     | [federation-staging.data.gov](https://federation-staging.data.gov/)
-`master`  | production  | [federation.data.gov](https://federation.data.gov/)
+Branch    | Environment | URL | Description
+------    | ----------- | --- | -----------
+`develop` | staging     | [federation-staging.data.gov](https://federation-staging.data.gov/) | Ad-hoc development and significant changes requiring partner review.
+`main`  | production  | [federation.data.gov](https://federation.data.gov/) | Production instance.
+
+Federalist automatically builds previews for all branches. Changes to `main` are
+automatically published to [federation.data.gov](https://federation.data.gov/).
+Feature branches should be branched from `main`.
+
+`develop` is used ad-hoc in order to preview significant changes with partners
+and is not part of the development workflow.
 
 
 ## Public domain


### PR DESCRIPTION
https://github.com/GSA/datagov-deploy/issues/2001

This proposes we simplify our workflow to make `main` the default branch.
`master` will be renamed to `main`. Feature branches will be branched from
`main` and then merged directly to `main` without going to staging/`develop`
first.

The staging site is used ad-hoc for significant changes but is otherwise unused.